### PR TITLE
Add security enforcement headers & theme output (Release 1.1.0)

### DIFF
--- a/wds-disable-pingbacks.php
+++ b/wds-disable-pingbacks.php
@@ -16,7 +16,7 @@
 
 add_filter( 'xmlrpc_methods', 'wds_disable_pingbacks' );
 add_action( 'current_screen', 'wds_disable_pingbacks_options' );
-add_filter( 'wp_headers', 'wds_disable_pingbacks_modify_wp_headers', 110, 2 );
+add_filter( 'wp_headers', 'wds_disable_pingbacks_modify_wp_headers', 110, 1 );
 add_filter( 'bloginfo_url', 'wds_disable_pingbacks_pingback_url', 11, 2 );
 
 /**
@@ -38,18 +38,21 @@ function wds_disable_pingbacks( $methods ) {
  * @param WP_Screen $screen The current admin screen we're on.
  * @author Justin Foell
  * @since  1.0.0
+ *
+ * @return void
  */
 function wds_disable_pingbacks_options( $screen ) {
-	if ( 'options-discussion' === $screen->id ) {
-		wp_register_script( 'wds-disable-pingbacks', plugins_url( 'wds-disable-pingbacks.js', __FILE__ ), 'jquery' ); // @codingStandardsIgnoreLine: Leave in header.
-
-		$translations = [
-			'disabled_message' => __( '(This has been globally disabled by the WDS Disable Pingbacks plugin.)', 'wds-disable-pingbacks' ),
-		];
-
-		wp_localize_script( 'wds-disable-pingbacks', 'wds_disable_pingbacks', $translations );
-		wp_enqueue_script( 'wds-disable-pingbacks' );
+	if ( 'options-discussion' !== $screen->id ) {
+		return;
 	}
+
+	wp_register_script( 'wds-disable-pingbacks', plugins_url( 'wds-disable-pingbacks.js', __FILE__ ), 'jquery' ); // @codingStandardsIgnoreLine: Leave in header.
+
+	wp_localize_script( 'wds-disable-pingbacks', 'wds_disable_pingbacks', [
+		'disabled_message' => __( '(This has been globally disabled by the WDS Disable Pingbacks plugin.)', 'wds-disable-pingbacks' ),
+	] );
+
+	wp_enqueue_script( 'wds-disable-pingbacks' );
 }
 
 /**
@@ -59,11 +62,10 @@ function wds_disable_pingbacks_options( $screen ) {
  * @since  1.1.0
  *
  * @param array $headers The headers.
- * @param mixed $wp_query Unused.
  *
  * @return array Modified headers.
  */
-function wds_disable_pingbacks_modify_wp_headers( $headers, $wp_query ) {
+function wds_disable_pingbacks_modify_wp_headers( $headers ) {
 	if ( isset( $headers['X-Pingback'] ) ) {
 		unset( $headers['X-Pingback'] );
 	}
@@ -78,7 +80,7 @@ function wds_disable_pingbacks_modify_wp_headers( $headers, $wp_query ) {
  * @since  1.1.0
  *
  * @param mixed  $output   The output of the URL (usually a string).
- * @param string $property Unused.
+ * @param string $property The property.
  *
  * @return mixed The output, null when disabled.
  */

--- a/wds-disable-pingbacks.php
+++ b/wds-disable-pingbacks.php
@@ -3,15 +3,22 @@
  * Plugin Name: WDS Disable Pingbacks
  * Plugin URI:  https://github.com/WebDevStudios/wds-disable-pingbacks
  * Description: Disables Pingbacks - all of them.
- * Version:     1.0.0
+ * Version:     1.1.0
  * Author:      WebDevStudios
  * Author URI:  https://webdevstudios.com
  * License:     GPLv2
  * Text Domain: wds-disable-pingbacks
  * Domain Path: /languages
+ *
+ * @package     WebDevStudios\wds-disable-pingbacks
+ * @since       1.0.0
  */
 
 add_filter( 'xmlrpc_methods', 'wds_disable_pingbacks' );
+add_action( 'current_screen', 'wds_disable_pingbacks_options' );
+add_filter( 'wp_headers', 'wds_disable_pingbacks_modify_wp_headers', 110, 2 );
+add_filter( 'bloginfo_url', 'wds_disable_pingbacks_pingback_url', 11, 2 );
+
 /**
  * Disable pingbacks in xmlrpc.php by removing it from the available methods list.
  *
@@ -25,7 +32,6 @@ function wds_disable_pingbacks( $methods ) {
 	return $methods;
 }
 
-add_action( 'current_screen', 'wds_disable_pingbacks_options' );
 /**
  * Disable the pingbacks checkbox on Settings -> Discussion and display a message.
  *
@@ -35,11 +41,47 @@ add_action( 'current_screen', 'wds_disable_pingbacks_options' );
  */
 function wds_disable_pingbacks_options( $screen ) {
 	if ( 'options-discussion' === $screen->id ) {
-		wp_register_script( 'wds-disable-pingbacks', plugins_url( 'wds-disable-pingbacks.js', __FILE__ ), 'jquery' );
-		$translations = array(
+		wp_register_script( 'wds-disable-pingbacks', plugins_url( 'wds-disable-pingbacks.js', __FILE__ ), 'jquery' ); // @codingStandardsIgnoreLine: Leave in header.
+
+		$translations = [
 			'disabled_message' => __( '(This has been globally disabled by the WDS Disable Pingbacks plugin.)', 'wds-disable-pingbacks' ),
-		);
+		];
+
 		wp_localize_script( 'wds-disable-pingbacks', 'wds_disable_pingbacks', $translations );
 		wp_enqueue_script( 'wds-disable-pingbacks' );
 	}
+}
+
+/**
+ * Ensure DOC headers are not recognized.
+ *
+ * @author Aubrey Portwood <aubrey@webdevstudios.com>
+ * @since  1.1.0
+ *
+ * @param array $headers The headers.
+ * @param mixed $wp_query Unused.
+ *
+ * @return array Modified headers.
+ */
+function wds_disable_pingbacks_modify_wp_headers( $headers, $wp_query ) {
+	if ( isset( $headers['X-Pingback'] ) ) {
+		unset( $headers['X-Pingback'] );
+	}
+
+	return $headers;
+}
+
+/**
+ * Hijack pingback_url for get_bloginfo (<link rel="pingback" />).
+ *
+ * @author Aubrey Portwood <aubrey@webdevstudios.com>
+ * @since  1.1.0
+ *
+ * @param mixed  $output   The output of the URL (usually a string).
+ * @param string $property Unused.
+ *
+ * @return mixed The output, null when disabled.
+ */
+function wds_disable_pingbacks_pingback_url( $output, $property ) {
+	return ( 'pingback_url' === $property ) ? null : $output;
 }


### PR DESCRIPTION
On MS we learned these things can also should also be taken into
consideration when disabling pingbacks. Adding it here so it can be
installed via package.

@jrfoell I can tag the 1.1.0 release when you okay this. 